### PR TITLE
US566181,US566186: Enable timestamp tooltip for one Timeseries chart up

### DIFF
--- a/px-vis-timeseries.html
+++ b/px-vis-timeseries.html
@@ -489,7 +489,7 @@ Custom property | Description
       margin="[[_internalMargin]]"
       complete-series-config="[[completeSeriesConfig]]"
       chart-data="[[chartData]]"
-      tooltip-data="[[_registerTooltipData]]"
+      tooltip-data="[[_cursorData]]"
       clip-path="[[seriesClipPath]]"
       muted-series="[[mutedSeries]]"
       hard-mute="[[hardMute]]"


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
*US566186: Timeseries chart : For timestamp mode display multiple horizontal lines and one vertical line

US566181: Enable timestamp tooltip for one Timeseries chart up

* ## A reference to a related issue (if applicable): US566186, US566181

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
